### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Example:
 ```js
 const server = require('fastify')()
 
-server.register(require('fastify-auth0-verify'))
+server.register(require('fastify-auth0-verify'), {
+  domain: "<auth0 app domain>",
+  audience: "<auth0 app audience>",
+})
 
 server.register(function(instance, _options, done) {
   instance.get('/verify', {


### PR DESCRIPTION
I was trying to use this package but the example given seems wrong. It says:

> Register as a plugin, providing one or more of the following options

But I didn't see where those options where provided. Perhaps they were Environment variables.

Anyways, I think it would be clearer if they were explicitly added as shown above. Then consumer can change them to environment variables.  Maybe it works in different way I didn't understand.