### PR TITLE
Decrease npm size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+test.js
+prettier.config.js
+.eslintrc.js
+.github/
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+coverage
+CHANGELOG.md


### PR DESCRIPTION
Using an `.npmignore` file drastically decreases the size of the npm package.
```
Without npmignore:
npm notice package size:  15.0 kB                                 
npm notice unpacked size: 50.2 kB 

With npmignore
npm notice package size:  4.7 kB                                  
npm notice unpacked size: 11.6 kB 
```