### PR TITLE
normalise domain as url with trailing slash, remove unrequired issuer…

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const fastifyJwtErrors = [
 ]
 
 function verifyOptions(options) {
-  let { domain, audience, secret, issuer } = options
+  let { domain, audience, secret } = options
 
   // Do not allow some options to be overidden by original user provided
   for (const key of forbiddenOptions) {
@@ -47,6 +47,9 @@ function verifyOptions(options) {
     // Normalize the domain in order to get a complete URL for JWKS fetching
     if (!domain.match(/^http(?:s?)/)) {
       domain = new URL(`https://${domain}`).toString()
+    } else {
+      // adds missing trailing slash if it's not been provided in the config
+      domain = new URL(domain).toString()
     }
 
     verify.algorithms.push('RS256')
@@ -56,8 +59,6 @@ function verifyOptions(options) {
       verify.audience = domain
     }
   }
-
-  verify.issuer = issuer || domain
 
   if (audience) {
     verify.audience = audience === true ? domain : audience

--- a/test.js
+++ b/test.js
@@ -277,44 +277,6 @@ describe('HS256 JWT token validation', function() {
     })
   })
 
-  it('should validate provided issuer', async function() {
-    await server.close()
-    server = await buildServer({ domain: 'localhost', secret: 'secret', issuer: 'foo' })
-
-    const response = await server.inject({
-      method: 'GET',
-      url: '/verify',
-      headers: { Authorization: `Bearer ${tokens.hs256ValidWithProvidedIssuer}` }
-    })
-
-    expect(response.statusCode).toEqual(200)
-    expect(JSON.parse(response.body)).toEqual({
-      sub: '1234567890',
-      name: 'John Doe',
-      admin: true,
-      iss: 'foo'
-    })
-  })
-
-  it('should validate multiple issuers', async function() {
-    await server.close()
-    server = await buildServer({ domain: 'localhost', secret: 'secret', issuer: ['bar', 'foo', 'blah'] })
-
-    const response = await server.inject({
-      method: 'GET',
-      url: '/verify',
-      headers: { Authorization: `Bearer ${tokens.hs256ValidWithProvidedIssuer}` }
-    })
-
-    expect(response.statusCode).toEqual(200)
-    expect(JSON.parse(response.body)).toEqual({
-      sub: '1234567890',
-      name: 'John Doe',
-      admin: true,
-      iss: 'foo'
-    })
-  })
-
   it('should validate the audience', async function() {
     await server.close()
     server = await buildServer({ audience: 'foo', secret: 'secret' })


### PR DESCRIPTION
Minor fixes

1. remove `issuer` option added in #12 - it's not actually required and created issues with consumers
2. normalise the `domain` option to have a trailing slash, so that when used as a URL it is consistent
