### PR TITLE
Restore issuer option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const fastifyJwtErrors = [
 ]
 
 function verifyOptions(options) {
-  let { domain, audience, secret } = options
+  let { domain, audience, secret, issuer } = options
 
   // Do not allow some options to be overidden by original user provided
   for (const key of forbiddenOptions) {
@@ -53,7 +53,7 @@ function verifyOptions(options) {
     }
 
     verify.algorithms.push('RS256')
-    verify.issuer = domain
+    verify.issuer = issuer || domain
 
     if (audience) {
       verify.audience = domain

--- a/test.js
+++ b/test.js
@@ -277,6 +277,44 @@ describe('HS256 JWT token validation', function() {
     })
   })
 
+  it('should validate provided issuer', async function() {
+    await server.close()
+    server = await buildServer({ domain: 'localhost', secret: 'secret', issuer: 'foo' })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/verify',
+      headers: { Authorization: `Bearer ${tokens.hs256ValidWithProvidedIssuer}` }
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(JSON.parse(response.body)).toEqual({
+      sub: '1234567890',
+      name: 'John Doe',
+      admin: true,
+      iss: 'foo'
+    })
+  })
+
+  it('should validate multiple issuers', async function() {
+    await server.close()
+    server = await buildServer({ domain: 'localhost', secret: 'secret', issuer: ['bar', 'foo', 'blah'] })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/verify',
+      headers: { Authorization: `Bearer ${tokens.hs256ValidWithProvidedIssuer}` }
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(JSON.parse(response.body)).toEqual({
+      sub: '1234567890',
+      name: 'John Doe',
+      admin: true,
+      iss: 'foo'
+    })
+  })
+
   it('should validate the audience', async function() {
     await server.close()
     server = await buildServer({ audience: 'foo', secret: 'secret' })


### PR DESCRIPTION
It appears that configuring multiple issuers was removed in #13, but it is a feature we will be needing. I noticed the comment in the that PR saying:

> 1. remove issuer option added in #12 - it's not actually required and created issues with consumers

If this is going to create issues, would there be a better way to go about getting multiple issuer support?

The documentation should still be fine for this PR since the option for issuer was never removed.