### PR TITLE
chore: add cli example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+You can run this example from the command line to validate a token using the plugin.
+
+All plugin options can be provided as command line arguments.
+
+A token must also be provided.
+
+### Example
+
+```sh
+node index.js --domain {auth0 domain} --token {auth0 id token}
+```

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,0 +1,37 @@
+const Fastify = require('fastify')
+
+async function run({ token, ...options }) {
+  if (!token) {
+    throw new Error('Please provide a token via --token {token}')
+  }
+
+  const fastify = Fastify()
+
+  await fastify.register(require('..'), options)
+
+  fastify.get(
+    '/',
+    {
+      preValidation: fastify.authenticate
+    },
+    r => r.user
+  )
+
+  const response = await fastify.inject({
+    url: '/',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  console.log('\n==============\n|  Response  |\n==============\n')
+  console.log(JSON.stringify(JSON.parse(response.body), null, 2))
+}
+
+run(
+  process.argv
+    .slice(2)
+    .map((o, i, _) => !(i % 2) && [o, _[i + 1]])
+    .filter(Boolean)
+    .reduce((o, [k, v]) => Object.assign(o, { [k.replace(/^--/, '')]: v }), {})
+)


### PR DESCRIPTION
After addressing https://github.com/nearform/fastify-auth0-verify/pull/41 I wanted to make a release but I also wanted to make sure I didn't break anything. Before releasing, I thought I'd put together a CLI example which can be run to use the plugin and check that it works against a real instance of Auth0.