### PR TITLE
Fixing type definition for jwtDecode (#144)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,9 @@
 import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify'
 import 'fastify-jwt'
 
-import { decode } from 'jsonwebtoken'
+import { DecodeOptions, JwtPayload, Jwt } from 'jsonwebtoken'
 import NodeCache from 'node-cache'
+
 
 export interface FastifyAuth0VerifyOptions {
   /**
@@ -46,6 +47,7 @@ export interface Auth0Verify extends Pick<FastifyAuth0VerifyOptions, 'domain' | 
 }
 
 export type Authenticate = (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+type JWTDecodedType = Record<string, unknown> | string
 
 /**
  * Auth0 verification plugin for Fastify, internally uses fastify-jwt and jsonwebtoken.
@@ -61,7 +63,7 @@ declare module 'fastify' {
 
   interface FastifyRequest {
     auth0Verify: Auth0Verify
-    jwtDecode: typeof decode
+    jwtDecode: (options?: DecodeOptions & { complete: true } | DecodeOptions & { json: true } | DecodeOptions) => null | JwtPayload | Jwt
     auth0VerifySecretsCache: Pick<NodeCache, 'get' | 'set' | 'close'>
   }
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,20 +1,34 @@
-import Fastify from 'fastify';
-import fastifyAuth0Verify from '.';
+import Fastify from 'fastify'
+import fastifyAuth0Verify from '.'
+import { expectAssignable, expectType } from 'tsd'
+import { DecodeOptions, JwtPayload, Jwt } from 'jsonwebtoken'
 
 const fastify = Fastify()
 
 fastify.register(fastifyAuth0Verify, {
-  domain: "<auth0 auth domain>",
-  audience: "<auth0 app audience>",
+  domain: '<auth0 auth domain>',
+  audience: '<auth0 app audience>'
 })
 fastify.register(fastifyAuth0Verify, {
   domain: '<auth0 auth domain>',
   audience: ['<auth0 app audience>', '<auth0 admin audience>']
 })
 
-fastify.register(function(instance, _options, done) {
+fastify.register(function (instance, _options, done) {
   instance.get('/verify', {
-    handler: function(request, reply) {
+    handler: function (request, reply) {
+      expectAssignable<Function>(request.jwtDecode)
+
+      const options: DecodeOptions = {
+        complete: true,
+        json: true
+      }
+
+      expectType<null | JwtPayload | Jwt>(request.jwtDecode(options))
+      expectType<null | JwtPayload | Jwt>(request.jwtDecode({ json: true }))
+      expectType<null | JwtPayload | Jwt>(request.jwtDecode({ complete: true }))
+      expectType<null | JwtPayload | Jwt>(request.jwtDecode())
+
       reply.send(request.user)
     },
     preValidation: instance.authenticate


### PR DESCRIPTION
Added type definition for the `jwtDecode` function. Also added type assertions in the **index.test-d.ts** file.
Closes #144. 