### PR TITLE
fix: add missing end of code block on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ server.listen(APP_PORT, err => {
     throw err
   }
 })
+```
 
 ## Contributing
 


### PR DESCRIPTION
Just a tiny fix, "Contributing" and "License" are inside the code block for the last example

![image](https://user-images.githubusercontent.com/8950721/136936989-d55ca73a-cce7-4d46-ac3d-d141c8caa788.png)
