### PR TITLE
Downgrade eslint v8 to v7.32 because of compatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "eslint": "^8.2.0",
+    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-config-standard": "^16.0.1",
     "eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
The `eslint-config-standard` is not yet compatible with `eslint` version 8, see https://github.com/standard/eslint-config-standard/issues/192. Since this is blocking the release I've decided to downgrade `eslint` to version 7.32.0 until the issue gets resolved. 