### PR TITLE
fix: add type definitions for cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Register as a plugin, providing one or more of the following options:
 - `secretsTtl`: How long (in milliseconds) to cache RS256 secrets before getting them again using well known JWKS URLS. Setting to 0 or less disables the cache.
 - `cookie`: Used to indicate that the token can be passed using cookie, instead of the Authorization header.
   - `cookieName`: The name of the cookie.
+  - `signed`: Indicates whether the cookie is signed or not. If set to `true`, the JWT will be verified using the unsigned value.
 
 Once registered, your fastify instance and request will be decorated as describe by `@fastify/jwt`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,22 @@ export interface FastifyAuth0VerifyOptions {
    * again using well known JWKS URLS. Setting to 0 or less disables the cache.
    */
   readonly secretsTtl?: string | number
+
+  /**
+   * Used to indicate that the token can be passed using cookie, instead of the Authorization header.
+   */
+  readonly cookie?: {
+    /**
+     *  The name of the cookie.
+     */
+    cookieName: string
+
+    /**
+     *  Indicates whether the cookie is signed or not. If set to `true`, the JWT
+     *  will be verified using the unsigned value.
+     */
+    signed?: boolean
+  }
 }
 
 export interface Auth0Verify extends Pick<FastifyAuth0VerifyOptions, 'domain' | 'audience' | 'secret'> {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,7 +19,13 @@ fastify.register(fastifyAuth0Verify, {
   audience: ['<auth0 app audience>', '<auth0 admin audience>']
 })
 fastify.register(fastifyJWT, {
-  secret: '<jwt secret>',
+  secret: '<jwt secret>'
+})
+fastify.register(fastifyAuth0Verify, {
+  cookie: {
+    cookieName: '<cookie>',
+    signed: true
+  }
 })
 
 fastify.register(function (instance, _options, done) {


### PR DESCRIPTION
hello! 👋 

came across some outdated types when using this library. i also added some docs for the `signed` property, taking inspiration from the docs over at https://github.com/fastify/fastify-jwt.

i set `signed` to optional as that will work with the code at https://github.com/fastify/fastify-jwt/blob/adcc618515a9c749bfbe9ee3198fa0a0edd13e7b/jwt.js#L233 but enforcing it could also make sense if we want to be explicit. what do you think? 

fixes https://github.com/nearform/fastify-auth0-verify/issues/235