### PR TITLE
fix: allow array of strings in issuer type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface FastifyAuth0VerifyOptions {
    * By default the domain will be also used as audience.
    * Accepts a string value, or an array of strings for multiple issuers.
    */
-  readonly issuer?: string
+  readonly issuer?: string | string[]
   /**
    * The Auth0 client secret. It enables verification of HS256 encoded JWT tokens.
    */

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,10 +8,12 @@ const fastify = Fastify()
 
 fastify.register(fastifyAuth0Verify, {
   domain: '<auth0 auth domain>',
+  issuer: '<auth0 issuer>',
   audience: '<auth0 app audience>'
 })
 fastify.register(fastifyAuth0Verify, {
   domain: '<auth0 auth domain>',
+  issuer: ['<auth0 issuer>'],
   audience: ['<auth0 app audience>', '<auth0 admin audience>']
 })
 fastify.register(fastifyAuth0Verify, {


### PR DESCRIPTION
hello! 👋

came across this one as well, we're making use of an array and it's supported according to the docs.

related to https://github.com/nearform/fastify-auth0-verify/pull/234 and fixes https://github.com/nearform/fastify-auth0-verify/issues/235