### PR TITLE
fix: Allow `issuer` to be a regex

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,9 +19,10 @@ export interface FastifyAuth0VerifyOptions {
   /**
    * The Auth0 issuer (iss), usually the API name.
    * By default the domain will be also used as audience.
-   * Accepts a string value, or an array of strings for multiple issuers.
+   * Accepts a string value, or an array of strings or regexes for multiple
+   * issuers.
    */
-  readonly issuer?: string | string[]
+  readonly issuer?: string | RegExp | (RegExp | string)[]
   /**
    * The Auth0 client secret. It enables verification of HS256 encoded JWT tokens.
    */

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,7 +13,12 @@ fastify.register(fastifyAuth0Verify, {
 })
 fastify.register(fastifyAuth0Verify, {
   domain: '<auth0 auth domain>',
-  issuer: ['<auth0 issuer>'],
+  issuer: /<auth0 issuer>/,
+  audience: '<auth0 app audience>'
+})
+fastify.register(fastifyAuth0Verify, {
+  domain: '<auth0 auth domain>',
+  issuer: ['<auth0 issuer>', /<auth0 issuer>/],
   audience: ['<auth0 app audience>', '<auth0 admin audience>']
 })
 fastify.register(fastifyAuth0Verify, {


### PR DESCRIPTION
See: https://github.com/nearform/fast-jwt/blob/5cf5dd30492e41489c35e68dda58937ce6d705b6/src/index.d.ts#L119