### PR TITLE
chore: enabling npm provenance integration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
@@ -28,6 +29,7 @@ jobs:
           npm-token: ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] || secrets.NPM_TOKEN }}
           optic-token: ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] || secrets.OPTIC_TOKEN }}
           semver: ${{ github.event.inputs.semver }}
+          provenance: true
           build-command: |
             npm install
 


### PR DESCRIPTION
- Resolves #295 
- Enabling NPM Provenance beta integration when publishing new versions to NPM.
- Resolves partially https://github.com/nearform/hub-draft-issues/issues/247