### PR TITLE
fix: Fastify-auth0-verify with Typescript #354

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,84 +3,90 @@ import { UserType, SignPayloadType } from '@fastify/jwt'
 
 import NodeCache from 'node-cache'
 
-export interface FastifyAuth0VerifyOptions {
-  /**
-   * The Auth0 tenant domain. It enables verification of RS256 encoded tokens.
-   * It is also used to verify the token issuer (iss).
-   * Either provide a domain or the full URL, including the trailing slash (https://domain.com/).
-   */
-  readonly domain?: string
-  /**
-   * The Auth0 audience (aud), usually the API name.
-   * If you provide the value true, the domain will be also used as audience.
-   * Accepts a string value, or an array of strings for multiple providers.
-   */
-  readonly audience?: string | readonly string[] | boolean
-  /**
-   * The Auth0 issuer (iss), usually the API name.
-   * By default the domain will be also used as audience.
-   * Accepts a string value, or an array of strings or regexes for multiple
-   * issuers.
-   */
-  readonly issuer?: string | RegExp | (RegExp | string)[]
-  /**
-   * The Auth0 client secret. It enables verification of HS256 encoded JWT tokens.
-   */
-  readonly secret?: string
-  /**
-   * If to return also the header and signature of the verified token.
-   */
-  readonly complete?: boolean
-  /**
-   * How long (in milliseconds) to cache RS256 secrets before getting them
-   * again using well known JWKS URLS. Setting to 0 or less disables the cache.
-   */
-  readonly secretsTtl?: string | number
-
-  /**
-   * Used to indicate that the token can be passed using cookie, instead of the Authorization header.
-   */
-  readonly cookie?: {
-    /**
-     *  The name of the cookie.
-     */
-    cookieName: string
-
-    /**
-     *  Indicates whether the cookie is signed or not. If set to `true`, the JWT
-     *  will be verified using the unsigned value.
-     */
-    signed?: boolean
-  }
-  /**
-   * You may customize the request.user object setting a custom sync function as parameter:
-   */
-  readonly formatUser?: (payload: SignPayloadType) => UserType
-}
-
-export interface Auth0Verify extends Pick<FastifyAuth0VerifyOptions, 'domain' | 'audience' | 'secret'> {
-  readonly verify: FastifyAuth0VerifyOptions & {
-    readonly algorithms: readonly string[]
-    readonly audience?: string | readonly string[]
-  }
-}
-
-export type Authenticate = (request: FastifyRequest, reply: FastifyReply) => Promise<void>
-
-/**
- * Auth0 verification plugin for Fastify, internally uses @fastify/jwt and jsonwebtoken.
- */
-export const fastifyAuth0Verify: FastifyPluginCallback<FastifyAuth0VerifyOptions>
-export default fastifyAuth0Verify
-
 declare module 'fastify' {
   interface FastifyInstance {
-    authenticate: Authenticate
-    auth0Verify: Auth0Verify
+    authenticate: fastifyAuth0Verify.Authenticate
+    auth0Verify: fastifyAuth0Verify.Auth0Verify
   }
 
   interface FastifyRequest {
-    auth0Verify: Auth0Verify
+    auth0Verify: fastifyAuth0Verify.Auth0Verify
     auth0VerifySecretsCache: Pick<NodeCache, 'get' | 'set' | 'close'>
   }
 }
+
+type FastifyAuth0Verify = FastifyPluginCallback<fastifyAuth0Verify.FastifyAuth0VerifyOptions>
+
+declare namespace fastifyAuth0Verify {
+  export interface FastifyAuth0VerifyOptions {
+    /**
+     * The Auth0 tenant domain. It enables verification of RS256 encoded tokens.
+     * It is also used to verify the token issuer (iss).
+     * Either provide a domain or the full URL, including the trailing slash (https://domain.com/).
+     */
+    readonly domain?: string
+    /**
+     * The Auth0 audience (aud), usually the API name.
+     * If you provide the value true, the domain will be also used as audience.
+     * Accepts a string value, or an array of strings for multiple providers.
+     */
+    readonly audience?: string | readonly string[] | boolean
+    /**
+     * The Auth0 issuer (iss), usually the API name.
+     * By default the domain will be also used as audience.
+     * Accepts a string value, or an array of strings or regexes for multiple
+     * issuers.
+     */
+    readonly issuer?: string | RegExp | (RegExp | string)[]
+    /**
+     * The Auth0 client secret. It enables verification of HS256 encoded JWT tokens.
+     */
+    readonly secret?: string
+    /**
+     * If to return also the header and signature of the verified token.
+     */
+    readonly complete?: boolean
+    /**
+     * How long (in milliseconds) to cache RS256 secrets before getting them
+     * again using well known JWKS URLS. Setting to 0 or less disables the cache.
+     */
+    readonly secretsTtl?: string | number
+
+    /**
+     * Used to indicate that the token can be passed using cookie, instead of the Authorization header.
+     */
+    readonly cookie?: {
+      /**
+       *  The name of the cookie.
+       */
+      cookieName: string
+
+      /**
+       *  Indicates whether the cookie is signed or not. If set to `true`, the JWT
+       *  will be verified using the unsigned value.
+       */
+      signed?: boolean
+    }
+    /**
+     * You may customize the request.user object setting a custom sync function as parameter:
+     */
+    readonly formatUser?: (payload: SignPayloadType) => UserType
+  }
+
+  export type Authenticate = (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+
+  export interface Auth0Verify
+    extends Pick<fastifyAuth0Verify.FastifyAuth0VerifyOptions, 'domain' | 'audience' | 'secret'> {
+    readonly verify: fastifyAuth0Verify.FastifyAuth0VerifyOptions & {
+      readonly algorithms: readonly string[]
+      readonly audience?: string | readonly string[]
+    }
+  }
+
+  export const fastifyAuth0Verify: FastifyAuth0Verify
+  export { fastifyAuth0Verify as default }
+}
+
+declare function fastifyAuth0Verify(...params: Parameters<FastifyAuth0Verify>): ReturnType<FastifyAuth0Verify>
+
+export = fastifyAuth0Verify

--- a/index.js
+++ b/index.js
@@ -44,3 +44,9 @@ function fastifyAuth0Verify(instance, options, done) {
 }
 
 module.exports = fastifyPlugin(fastifyAuth0Verify, { name: 'fastify-auth0-verify', fastify: '4.x' })
+
+// Set the default export to the fastifyAuth0Verify function for ES module compatibility
+module.exports.default = fastifyAuth0Verify
+
+// Add a named export for the fastifyAuth0Verify function for CommonJS compatibility
+module.exports.fastifyAuth0Verify = fastifyAuth0Verify


### PR DESCRIPTION
Fixes: #354

Updated module export statements & type declarations inspired from fastify-jwt

https://github.com/fastify/fastify-jwt/blob/138a13ec021d871b1d5117832c3904f49c31b9b8/jwt.js#L548-L553

https://github.com/fastify/fastify-jwt/blob/138a13ec021d871b1d5117832c3904f49c31b9b8/types/jwt.d.ts#L1-L211

![image](https://github.com/nearform/fastify-auth0-verify/assets/10779658/f67e951b-58ba-47ad-a48a-591bfdb02314)
