### PR TITLE
chore(deps): update fastify-jwt-jwks to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fastify/cookie": "^11.0.2",
     "@fastify/jwt": "^10.0.0",
-    "fastify-jwt-jwks": "^2.0.3",
+    "fastify-jwt-jwks": "^3.0.0",
     "fastify-plugin": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates fastify-jwt-jwks to v3.0.0 and makes the package stable with `@fastify/jwt` v10 in the dependencies tree.