### PR TITLE
chore(deps): bump fastify-jwt-jwks to ^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fastify/cookie": "^11.0.2",
     "@fastify/jwt": "^10.0.0",
-    "fastify-jwt-jwks": "^3.0.0",
+    "fastify-jwt-jwks": "^3.0.2",
     "fastify-plugin": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- v3.0.0 and v3.0.1 of `fastify-jwt-jwks` were published without `error-messages.js` and `get-header.js` (missing from the `files` whitelist), so every install of v3.0.x threw `Cannot find module './error-messages'` and broke the test suite here.
- Upstream fix: nearform/fastify-jwt-jwks#61, released as v3.0.2.
- This PR bumps the dependency range so a fresh install picks up the working tarball.

## Test plan
- [x] `npm test` — 42/42 pass, 100% coverage
- [x] `npm run test:types` — tstyche 4/4 pass
- [x] `npm run test:integration` — 2/2 pass (real Auth0 round-trip)
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)