### PR TITLE
fix(ci): pin npm to 11.x for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,6 @@ jobs:
           semver: ${{ github.event.inputs.semver }}
           publish-mode: oidc
           build-command: |
+            npm install -g npm@11
             npm install
 


### PR DESCRIPTION
npm 12.0.0 has a bug (npm/cli#9722) that prevents publishing. Install npm@11 in the release build-command so the publish step runs on npm 11.x until the upstream issue is resolved.

Fixes #430